### PR TITLE
 validate medical repott uploads and restrict ssuported file types

### DIFF
--- a/client/src/components/Upload.jsx
+++ b/client/src/components/Upload.jsx
@@ -1,6 +1,11 @@
 import { useState  } from "react";
 import { useNavigate } from "react-router-dom";
 
+const SUPPORTED_FILE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+];
 
 const Upload = () => {
   const [rawtext, setRawText] = useState("");
@@ -18,7 +23,17 @@ const Upload = () => {
   const handleUpload = async (e) => {
     e.preventDefault();
     if (!file) return alert("Upload a File");
+
+    if (!SUPPORTED_FILE_TYPES.includes(file.type)) {
+      alert("Please upload a JPG, PNG, or WEBP image.");
+      return;
+    }
+
     setLoading(true);
+    setRawText("");
+    setEnglishSummary("");
+    setHindiSummary("");
+    setMedSummary("");
     const formdata = new FormData();
     formdata.append("report", file);
     formdata.append("phone", phone);
@@ -87,7 +102,7 @@ const Upload = () => {
         <div className="bg-white/60 backdrop-blur-2xl rounded-3xl shadow-2xl p-8 border border-white/50 transform transition-all duration-500 hover:shadow-[0_20px_80px_rgba(103,198,227,0.3)]">
           <div className="mb-6">
             <h2 className="text-2xl font-bold text-gray-800 mb-2">Upload Medical Report</h2>
-            <p className="text-gray-600">Select a medical report file to analyze and get multilingual summaries</p>
+            <p className="text-gray-600">Upload a clear JPG, PNG, or WEBP image of the report for multilingual analysis</p>
           </div>
           
           <form onSubmit={handleUpload} className="space-y-6">
@@ -100,7 +115,7 @@ const Upload = () => {
                   type="file"
                   onChange={(e) => setFile(e.target.files[0])}
                   className="w-full text-sm text-gray-600 file:mr-4 file:py-3 file:px-6 file:rounded-xl file:border-0 file:text-sm file:font-semibold file:bg-gradient-to-r file:from-[#67C6E3] file:to-[#5BB8D8] file:text-white hover:file:shadow-lg file:transition-all file:cursor-pointer cursor-pointer"
-                  accept=".pdf,.doc,.docx,.txt"
+                  accept="image/png,image/jpeg,image/webp"
                 />
                 {file && (
                   <div className="mt-3 flex items-center justify-center gap-2">
@@ -108,6 +123,9 @@ const Upload = () => {
                   </div>
                 )}
               </div>
+              <p className="mt-2 text-sm text-gray-500">
+                Supported files: JPG, PNG, WEBP
+              </p>
             </div>
             
             <button

--- a/server/controllers/uploadController.js
+++ b/server/controllers/uploadController.js
@@ -3,9 +3,21 @@ const Tesseract = require('tesseract.js');
 const fs = require('fs');
 const User = require("../models/User");
 
+const supportedMimeTypes = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
 exports.Upload = async (req, res) => {
   if (!req.file) {
     return res.status(400).json({ error: "Report file is required" });
+  }
+
+  if (!supportedMimeTypes.has(req.file.mimetype)) {
+    return res
+      .status(400)
+      .json({ error: "Unsupported file type. Please upload a JPG, PNG, or WEBP image." });
   }
 
   const filePath = req.file.path;

--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -1,9 +1,42 @@
-const express = require("express")
+const express = require("express");
 const router = express.Router();
-const multer  = require('multer')
-const uploadController = require("../controllers/uploadController")
+const multer = require("multer");
+const uploadController = require("../controllers/uploadController");
 const { verifyToken } = require("../middleware/authMiddleware");
-const upload = multer({ dest: 'uploads/' })
-router.post('/upload', verifyToken, upload.single('report'), uploadController.Upload)
 
-module.exports=router;
+const supportedMimeTypes = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+];
+
+const upload = multer({
+  dest: "uploads/",
+  fileFilter: (req, file, cb) => {
+    if (supportedMimeTypes.includes(file.mimetype)) {
+      return cb(null, true);
+    }
+
+    return cb(
+      new Error("Unsupported file type. Please upload a JPG, PNG, or WEBP image.")
+    );
+  },
+});
+
+const handleUpload = (req, res, next) => {
+  upload.single("report")(req, res, (err) => {
+    if (!err) {
+      return next();
+    }
+
+    if (err instanceof multer.MulterError) {
+      return res.status(400).json({ error: err.message });
+    }
+
+    return res.status(400).json({ error: err.message || "Invalid file upload" });
+  });
+};
+
+router.post("/upload", verifyToken, handleUpload, uploadController.Upload);
+
+module.exports = router;


### PR DESCRIPTION
- Added server-side file type validation for uploads
- Rejected unsupported files with a clear 400 error message
- Restricted frontend file input to supported image formats only
- Updated upload UI copy to reflect actual supported formats
- Cleared old summary state before a new upload

Author: @goyaljiiiiii | contributor at apertre 3.0

reference issue #19 